### PR TITLE
Allowed failure is not necessary anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,3 @@ env:
     - GCOV_FLAG=
 script:
     - ./autogen.sh && ./configure $GCOV_FLAG && make check
-matrix:
-  # At this moment Travis has clang 3.3 installed on Linux machines and a bug
-  # has been reported with this version and the coverage feature on Linux:
-  # http://llvm.org/bugs/show_bug.cgi?id=15953
-  #
-  # It must work on clang 3.4
-  allow_failures:
-    - compiler: clang
-      env: GCOV_FLAG=--enable-gcov


### PR DESCRIPTION
Now Travis has clang 3.4 installed, so the exception is not necessary anymore.
You can see it in my repo with the new Travis file https://travis-ci.org/Kerrigan29a/cmockery2
