### PR TITLE
port: FreeBSD port update

### DIFF
--- a/packages/FreeBSD/Makefile
+++ b/packages/FreeBSD/Makefile
@@ -18,8 +18,12 @@ WRKSRC=           ${WRKDIR}/cmockery2-${PORTVERSION}
 
 PLIST_SUB+=       RESETPREFIX=${PREFIX}
 
+BUILD_DEPENDS+=   automake:${PORTSDIR}/devel/automake
+BUILD_DEPENDS+=   autoconf:${PORTSDIR}/devel/autoconf
 BUILD_DEPENDS+=   pkgconf:${PORTSDIR}/devel/pkgconf
+BUILD_DEPENDS+=   libtool:${PORTSDIR}/devel/libtool
 
+USES=             libtool
 GNU_CONFIGURE=    yes
 
 INSTALL_TARGET=   install-strip

--- a/packages/FreeBSD/pkg-plist
+++ b/packages/FreeBSD/pkg-plist
@@ -4,6 +4,7 @@ include/cmockery/pbc.h
 lib/libcmockery.a
 lib/libcmockery.so
 lib/libcmockery.so.0
+lib/libcmockery.so.0.0.0
 lib/pkgconfig/cmockery2.pc
 %%PORTDOCS%%%%DOCSDIR%%-1.3.8/AUTHORS
 %%PORTDOCS%%%%DOCSDIR%%-1.3.8/COPYING


### PR DESCRIPTION
Final update for FreeBSD inclusion at -
   https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=192420

Passes

> make check-plist
> make stage-qa
> poudriere testport -o sysutils/cmockery2 -j cmockery2
> poudriere bulk -C -t -j cmockery2 sysutils/cmockery2
