### PR TITLE
Add subdir-objects automake option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,9 @@ ACLOCAL_AMFLAGS = -I m4
 # This is so we can #include <cmockery/foo>
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/src/cmockery
 
+# Allow .o files in subdirectories
+AUTOMAKE_OPTIONS = subdir-objects
+
 cmockeryincludedir = $(includedir)/cmockery
 ## The .h files you want to install (that is, .h files that people
 ## who install this package can include in their own applications.)


### PR DESCRIPTION
Fixes this error with newer automake (eg 1.14.1):

```
$ ./autogen.sh 
Running aclocal ...
Running autoheader ...
Running glibtoolize ...
Running autoconf ...
Running automake ...
configure.ac:19: installing './ar-lib'
configure.ac:18: installing './compile'
configure.ac:66: installing './config.guess'
configure.ac:66: installing './config.sub'
configure.ac:17: installing './install-sh'
configure.ac:17: installing './missing'
Makefile.am:48: warning: source file 'src/cmockery.c' is in a subdirectory,
Makefile.am:48: but option 'subdir-objects' is disabled
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
Makefile.am:74: warning: source file 'src/example/allocate_module_test.c' is in a subdirectory,
Makefile.am:74: but option 'subdir-objects' is disabled
Makefile.am:74: warning: source file 'src/example/allocate_module.c' is in a subdirectory,
Makefile.am:74: but option 'subdir-objects' is disabled
Makefile.am:81: warning: source file 'src/example/assert_macro_test.c' is in a subdirectory,
Makefile.am:81: but option 'subdir-objects' is disabled
Makefile.am:81: warning: source file 'src/example/assert_macro.c' is in a subdirectory,
Makefile.am:81: but option 'subdir-objects' is disabled
Makefile.am:57: warning: source file 'src/example/calculator.c' is in a subdirectory,
Makefile.am:57: but option 'subdir-objects' is disabled
Makefile.am:66: warning: source file 'src/example/calculator_test.c' is in a subdirectory,
Makefile.am:66: but option 'subdir-objects' is disabled
Makefile.am:88: warning: source file 'src/example/customer_database_test.c' is in a subdirectory,
Makefile.am:88: but option 'subdir-objects' is disabled
Makefile.am:88: warning: source file 'src/example/customer_database.c' is in a subdirectory,
Makefile.am:88: but option 'subdir-objects' is disabled
Makefile.am:96: warning: source file 'src/example/key_value_test.c' is in a subdirectory,
Makefile.am:96: but option 'subdir-objects' is disabled
Makefile.am:96: warning: source file 'src/example/key_value.c' is in a subdirectory,
Makefile.am:96: but option 'subdir-objects' is disabled
Makefile.am:125: warning: source file 'src/example/mem_test.c' is in a subdirectory,
Makefile.am:125: but option 'subdir-objects' is disabled
Makefile.am:105: warning: source file 'src/example/product_database_test.c' is in a subdirectory,
Makefile.am:105: but option 'subdir-objects' is disabled
Makefile.am:105: warning: source file 'src/example/product_database.c' is in a subdirectory,
Makefile.am:105: but option 'subdir-objects' is disabled
Makefile.am:119: warning: source file 'src/example/realloc_test.c' is in a subdirectory,
Makefile.am:119: but option 'subdir-objects' is disabled
Makefile.am:113: warning: source file 'src/example/run_tests.c' is in a subdirectory,
Makefile.am:113: but option 'subdir-objects' is disabled
Makefile.am: installing './depcomp'
parallel-tests: installing './test-driver'
$
```
