### PR TITLE
Update assert_module.c

### DIFF
--- a/src/example/assert_module.c
+++ b/src/example/assert_module.c
@@ -17,6 +17,7 @@
 
 // If unit testing is enabled override assert with mock_assert().
 #ifdef UNIT_TESTING
+#include <stdio.h>
 #include <cmockery_override.h>
 #endif
 


### PR DESCRIPTION
add including of stdio.h for type error of "size_t" used in cmockery_override.h