### PR TITLE
PBC minor changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: c
 compiler:
     - gcc
     - clang
+sudo:false
 env:
   matrix:
     - GCOV_FLAG=--enable-gcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 compiler:
     - gcc
     - clang
-sudo:false
+sudo: false
 env:
   matrix:
     - GCOV_FLAG=--enable-gcov

--- a/src/cmockery/cmockery_override.h
+++ b/src/cmockery/cmockery_override.h
@@ -64,7 +64,7 @@ extern void mock_assert(const int result, const char* const expression,
 
 /* Redirect to use test functions */
 #define assert(expression) \
-    mock_assert((int)(expression), #expression, __FILE__, __LINE__);
+    mock_assert((int)(expression), #expression, __FILE__, __LINE__)
 
 // Redirect malloc, calloc and free to the unit test allocators.
 #define test_malloc(size) _test_malloc(size, __FILE__, __LINE__)

--- a/src/cmockery/pbc.h
+++ b/src/cmockery/pbc.h
@@ -37,12 +37,12 @@
 /*
  * Checks caller responsibility against contract
  */
-#define REQUIRE(cond) assert(cond)
+#define REQUIRE(cond)   assert(cond)
 
 /*
  * Checks function reponsability against contract.
  */
-#define ENSURE(cond) assert(cond)
+#define ENSURE(cond)    assert(cond)
 
 /*
  * While REQUIRE and ENSURE apply to functions, INVARIANT
@@ -50,12 +50,13 @@
  * of the class/struct are consistent. In other words,
  * that the instance has not been corrupted.
  */
-#define INVARIANT(invariant_fnc) do{ (invariant_fnc) } while (0);
+#define INVARIANT(cond) assert(cond)
 
 #else
-#define REQUIRE(cond) do { } while (0);
-#define ENSURE(cond) do { } while (0);
-#define INVARIANT(invariant_fnc) do{ } while (0);
+
+#define REQUIRE(cond)   ((void) 0)
+#define ENSURE(cond)    ((void) 0)
+#define INVARIANT(cond) ((void) 0)
 
 #endif /* defined(UNIT_TESTING) || defined (DEBUG) */
 #endif /* CMOCKERY_PBC_H_ */


### PR DESCRIPTION
Some changes:
- Added Travis CI support to [container based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/)
- Deleted some semicolons at the end of macros.
- New definition of disabled macros. Why don't the standard way to disable a macro, like in assert definition?
- New definition of INVARIANT. Why don't use assert, like in the other macros?

Sorry for my "plain" english. I would be very pleased to explain these changes if you want with more detailed examples.