### PR TITLE
pbc: Replaced mistaken commit

### DIFF
--- a/src/cmockery/pbc.h
+++ b/src/cmockery/pbc.h
@@ -50,13 +50,13 @@
  * of the class/struct are consistent. In other words,
  * that the instance has not been corrupted.
  */
-#define INVARIANT(cond) assert(cond)
+#define INVARIANT(invariant_fnc) do { (invariant_fnc) } while (0)
 
 #else
 
-#define REQUIRE(cond)   ((void) 0)
-#define ENSURE(cond)    ((void) 0)
-#define INVARIANT(cond) ((void) 0)
+#define REQUIRE(cond)   do {} while (0)
+#define ENSURE(cond)    do {} while (0)
+#define INVARIANT(invariant_fnc) do {} while (0)
 
 #endif /* defined(UNIT_TESTING) || defined (DEBUG) */
 #endif /* CMOCKERY_PBC_H_ */


### PR DESCRIPTION
I commited pull #19 prematurely.  Invariant must be a call
to a function so that it checks the object.  Also, when debug
is not set, we need to use do{}while(0) style in case any of the
pbc macros are used inside an 'if' statement without using {}.

Signed-off-by: Luis Pabón <lpabon@redhat.com>