### PR TITLE
Fixed expect_check() and expect_in_set()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,7 @@ lib_LTLIBRARIES =
 ## TESTS is for binary unittests, check_SCRIPTS for script-based unittests.
 ## TESTS_ENVIRONMENT sets environment variables for when you run unittest,
 ## but it only seems to take effect for *binary* unittests (argh!)
-TESTS = 
+TESTS =
 check_SCRIPTS =
 noinst_SCRIPTS =
 
@@ -107,6 +107,12 @@ nodist_product_database_test_SOURCES = src/example/product_database_test.c \
                                 src/example/database.h
 product_database_test_CFLAGS = $(unit_test_CFLAGS)
 product_database_test_LDADD = libcmockery.la
+
+noinst_PROGRAMS += game_test
+TESTS += game_test
+nodist_game_test_SOURCES = src/example/game_test.c src/example/game.c
+game_test_CFLAGS = $(unit_test_CFLAGS)
+game_test_LDADD = libcmockery.la
 
 noinst_PROGRAMS += run_tests
 TESTS += run_tests

--- a/src/cmockery.c
+++ b/src/cmockery.c
@@ -972,6 +972,7 @@ static void expect_set(
     assert_true(number_of_values);
     memcpy(set, values, number_of_values * sizeof(values[0]));
     check_integer_set->set = set;
+    check_integer_set->size_of_set = number_of_values;
     _expect_check(
         function, parameter, file, line, check_function,
         check_data.value, &check_integer_set->event, count);

--- a/src/cmockery/cmockery.h
+++ b/src/cmockery/cmockery.h
@@ -140,7 +140,7 @@ cast_to_largest_integral_type(cast_to_pointer_integral_type(value))
  */
 #define expect_check(function, parameter, check_function, check_data) \
     _expect_check(#function, #parameter, __FILE__, __LINE__, check_function, \
-                  cast_to_largest_integral_type(check_data), NULL, 0)
+                  cast_to_largest_integral_type(check_data), NULL, 1)
 
 /* Add an event to check a parameter, using check_expected(), against a set of
  * values. See will_return() for a description of the count parameter.

--- a/src/example/game.c
+++ b/src/example/game.c
@@ -1,0 +1,10 @@
+
+#include <stdlib.h>
+
+struct game_event;
+
+void run_game(void (*event_handler)(struct game_event *event), struct game_event *events[], int num_events)
+{
+	int i = rand() % num_events;
+	event_handler(events[i]);
+} /* run_game */

--- a/src/example/game_test.c
+++ b/src/example/game_test.c
@@ -1,0 +1,87 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <inttypes.h>
+#include <cmockery.h>
+
+struct game_event {
+    int id;
+    const char *message;
+};
+
+extern void run_game(void (*event_handler)(struct game_event *), struct game_event *events[], int num_events);
+
+/* Our version of "expect_string()". It only compares as much of the message as given by the check-string length. */
+static int check_event_message(const uintmax_t value, const uintmax_t check_value_data)
+{
+    const char *message = (const char *)value;
+    const char *check = (const char *)check_value_data;
+    assert_non_null(message);
+    assert_non_null(check);
+
+    /* Compare only the first part of the message determined by the check-string. */
+    return( memcmp(message, check, strlen(check)) == 0 );
+} /* check_event_message */
+
+static void my_event_handler1(struct game_event *event)
+{
+    check_expected(event->id);
+} /* my_event_handler1 */
+
+static void my_event_handler2(struct game_event *event)
+{
+    check_expected(event->message);
+} /* my_event_handler1 */
+
+static void test_run_game1(void **state)
+{
+    int i;
+    uintmax_t event_ids[5] = { 0, 1, 2, 3, 4 };
+
+    struct game_event game_events[5] = {
+        { 3, "Event 3" },
+        { 1, "Event 1" },
+        { 4, "Event 4" },
+        { 2, "Event 2" },
+        { 0, "Event 0" },
+    };
+
+    struct game_event *events[5];
+
+    /* Populate the event list. */
+    for (i = 0; i < 5; i++) events[i] = &game_events[i];
+
+    expect_in_set(my_event_handler1, event->id, event_ids);
+    run_game(my_event_handler1, events, 5);
+} /* test_run_game */
+
+static void test_run_game2(void **state)
+{
+    int i;
+
+    struct game_event game_events[5] = {
+        { 3, "Event: BANG" },
+        { 1, "Event: BONG" },
+        { 4, "Event: PING" },
+        { 2, "Event: ZOOM" },
+        { 0, "Event: POP" },
+    };
+
+    struct game_event *events[5];
+
+    /* Populate the event list. */
+    for (i = 0; i < 5; i++) events[i] = &game_events[i];
+
+    expect_check(my_event_handler2, event->message, check_event_message, "Event: ");
+    run_game(my_event_handler2, events, 5);
+} /* test_run_game2 */
+
+int main(void) {
+    const UnitTest tests[] = {
+        unit_test(test_run_game1),
+        unit_test(test_run_game2),
+    };
+    return run_tests(tests, "game");
+}


### PR DESCRIPTION
During routine testing I discovered that expect_check() and expect_in_set() were broken. Please consider the following patch to fix them.