### PR TITLE
Remove warning flags from pkgconfig file

### DIFF
--- a/cmockery2.pc.in
+++ b/cmockery2.pc.in
@@ -8,4 +8,4 @@ Version: @PACKAGE_VERSION@
 Description: Lightweight C unit testing framework with mocking support.
 
 Libs: -L${libdir} -lcmockery @LIBS@
-Cflags: -I${includedir} -Wall -Werror -DUNIT_TESTING=1
+Cflags: -I${includedir} -DUNIT_TESTING=1


### PR DESCRIPTION
This is relevant to me because I'm building something that has warnings on the newer glibc, and since it uses cmockery, they are fatal.
-Werror might be useful to the developers of the program if they are motivated, but I am not one, but they didn't check with my exact setup (very new glibc).
it's best not to force cmockery users to use -Werror.